### PR TITLE
Replace boolean() for logical() to remove Simulink dependency.

### DIFF
--- a/core/ssd_init.m
+++ b/core/ssd_init.m
@@ -236,7 +236,7 @@ function [confOut, locOut] = getOutSize(maxSize, aspectRatios, opts)
 % aspect ratios)
 
   numBBoxOffsets = 4 ;
-  priorsPerFeature = 1 + boolean(maxSize) + numel(aspectRatios) * 2 ;
+  priorsPerFeature = 1 + logical(maxSize) + numel(aspectRatios) * 2 ;
   confOut = opts.modelOpts.numClasses * priorsPerFeature ;
   locOut = numBBoxOffsets * priorsPerFeature ;
 

--- a/core/ssd_mini_init.m
+++ b/core/ssd_mini_init.m
@@ -201,7 +201,7 @@ function [confOut, locOut] = getOutSize(maxSize, aspectRatios, opts)
 % aspect ratios)
 
 numBBoxOffsets = 4 ;
-priorsPerFeature = 1 + boolean(maxSize) + numel(aspectRatios) * 2 ;
+priorsPerFeature = 1 + logical(maxSize) + numel(aspectRatios) * 2 ;
 confOut = opts.modelOpts.numClasses * priorsPerFeature ;
 locOut = numBBoxOffsets * priorsPerFeature ;
 


### PR DESCRIPTION
boolean() is a Simulink function which is an alias of the logical() function, which is already built in MATLAB. If we replace it you remove the dependency from Simulink